### PR TITLE
Update macOS example config to Xcode 26.3.0 and m4pro.medium

### DIFF
--- a/docs/guides/modules/execution-managed/pages/hello-world-macos.adoc
+++ b/docs/guides/modules/execution-managed/pages/hello-world-macos.adoc
@@ -56,7 +56,8 @@ version: 2.1
 jobs: # a basic unit of work in a run
   test: # your job name
     macos:
-      xcode: 14.2.0 # indicate your selected version of Xcode
+      xcode: 26.3.0 # indicate your selected version of Xcode
+    resource_class: m4pro.medium # specify a resource class (e.g. m4pro.medium or m4pro.large)
     steps: # a series of commands to run
       - checkout  # pull down code from your version control system.
       - run:
@@ -65,7 +66,8 @@ jobs: # a basic unit of work in a run
 
   build:
     macos:
-      xcode: 14.2.0 # indicate your selected version of Xcode
+      xcode: 26.3.0 # indicate your selected version of Xcode
+    resource_class: m4pro.medium # specify a resource class (e.g. m4pro.medium or m4pro.large)
     steps:
       - checkout
       - run:


### PR DESCRIPTION
# Description

Updated the macOS hello-world example configuration file to use Xcode 26.3.0 and added `resource_class: m4pro.medium` to both the `test` and `build` jobs.

# Reasons

The example config referenced Xcode 14.2.0, which is outdated. Updated to reflect current Xcode availability and added the `m4pro.medium` resource class to demonstrate recommended usage with Apple Silicon runners, helping contributors get accurate, working configs from the docs.

# Content checks

**Preview your changes:**
- [x] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR.
- [x] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR.

**Content structure:**
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables.
- [x] Consider whether the content would benefit from more subsections.
- [x] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [x] Keep the title between 20 and 70 characters.
- [x] Check all headings h1-h6 are in sentence case.